### PR TITLE
feat: agentic loop with bash exec, ctx management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,6 @@ bin/
 
 # Air
 tmp/
+
+# User config
+config.toml

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,0 +1,55 @@
+# Banray Bot Configuration
+#
+# Copy this file to config.toml and customize for your use case.
+# Add tool-specific context files to .context/*.md
+
+[prompts]
+
+# System prompt for simple (non-agentic) mode
+simple = """
+You are a helpful Telegram bot assistant. Provide brief, concise responses with a friendly tone.
+
+Guidelines:
+- Be direct and helpful
+- Keep responses short unless detail is requested
+- Do not use markdown formatting (Telegram has limited support)
+- If you don't know something, say so
+"""
+
+# System prompt for agentic mode with bash access
+agent = """
+You are an autonomous Telegram bot assistant with bash access. You help users by executing commands and using available CLI tools.
+
+## How to Respond
+
+Respond with exactly ONE bash command in a code block:
+
+```bash
+your command here
+```
+
+After each command, you'll see the output. Use it to decide your next action.
+
+## When Done
+
+Signal completion with BOTH echo statements using SINGLE QUOTES:
+
+```bash
+echo 'TASK_COMPLETE'
+echo 'Your response to the user here'
+```
+
+IMPORTANT:
+- Both lines must use echo with SINGLE QUOTES (not double quotes)
+- Single quotes prevent bash from mangling dollar signs like $5.00
+- Do not use \n for newlines - keep response on one line
+
+## Rules
+
+1. One command per response - never multiple code blocks
+2. If a command fails, DO NOT give up - try an alternative approach
+3. Use tool flags like -f llm or --json for compact output when available
+4. Keep final responses concise and friendly (it's a chat message)
+5. If output is large or truncated, extract only the specific data needed
+6. Refer to the Available Tools section below for CLI tools you can use
+"""

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/internal/agent/action.go
+++ b/internal/agent/action.go
@@ -1,0 +1,41 @@
+package agent
+
+import "fmt"
+
+// ActionType represents the type of action to execute.
+type ActionType string
+
+const (
+	ActionTypeBash ActionType = "bash"
+)
+
+// Action represents a parsed command to execute.
+type Action struct {
+	Type    ActionType
+	Command string
+}
+
+// String returns a string representation of the action for debugging.
+func (a Action) String() string {
+	return fmt.Sprintf("%s: %s", a.Type, a.Command)
+}
+
+// Output represents the result of command execution.
+type Output struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+	TimedOut bool
+}
+
+// String formats the output for display to the LLM.
+func (o Output) String() string {
+	result := o.Stdout
+	if o.Stderr != "" {
+		result += "\nstderr: " + o.Stderr
+	}
+	if o.ExitCode != 0 {
+		result += fmt.Sprintf("\nexit code: %d", o.ExitCode)
+	}
+	return result
+}

--- a/internal/agent/errors.go
+++ b/internal/agent/errors.go
@@ -1,0 +1,41 @@
+package agent
+
+import "fmt"
+
+// TerminationReason indicates why the agent stopped.
+type TerminationReason string
+
+const (
+	ReasonComplete  TerminationReason = "complete"
+	ReasonStepLimit TerminationReason = "step_limit"
+)
+
+// TerminatingErr signals the agent should stop the loop.
+type TerminatingErr struct {
+	Reason TerminationReason
+	Output string // Optional final output
+}
+
+func (e *TerminatingErr) Error() string {
+	return fmt.Sprintf("terminating: %s", e.Reason)
+}
+
+// ProcessErrType indicates the type of recoverable error.
+type ProcessErrType string
+
+const (
+	ProcessErrFormat    ProcessErrType = "format"
+	ProcessErrTimeout   ProcessErrType = "timeout"
+	ProcessErrExecution ProcessErrType = "execution"
+)
+
+// ProcessErr signals a recoverable error. The agent should add
+// feedback to messages and continue the loop.
+type ProcessErr struct {
+	Type    ProcessErrType
+	Message string // Feedback to add to conversation
+}
+
+func (e *ProcessErr) Error() string {
+	return fmt.Sprintf("process error [%s]: %s", e.Type, e.Message)
+}

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -1,0 +1,191 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"time"
+)
+
+// Executor runs actions in the environment.
+type Executor interface {
+	Execute(ctx context.Context, action Action) (Output, error)
+}
+
+// CommandValidator checks if a command is safe to execute.
+type CommandValidator interface {
+	Validate(command string) error
+}
+
+// BlocklistValidator blocks commands matching dangerous patterns.
+type BlocklistValidator struct {
+	patterns []*regexp.Regexp
+}
+
+// DefaultBlockedPatterns contains patterns for dangerous commands.
+var DefaultBlockedPatterns = []string{
+	`rm\s+-[rf]*\s+/`,           // rm -rf / or rm -r / or rm -f /
+	`rm\s+-[rf]*\s+\*`,          // rm -rf * or similar
+	`rm\s+-[rf]*\s+~`,           // rm -rf ~
+	`>\s*/dev/sd`,               // writing to disk devices
+	`mkfs`,                      // formatting filesystems
+	`dd\s+if=.*/dev/`,           // dd from devices
+	`dd\s+of=.*/dev/`,           // dd to devices
+	`chmod\s+777\s+/`,           // chmod 777 on root
+	`chown\s+-R\s+.*\s+/`,       // recursive chown on root
+	`curl.*\|\s*(ba)?sh`,        // curl | sh (pipe to shell)
+	`wget.*\|\s*(ba)?sh`,        // wget | sh
+	`:\(\)\{\s*:\|:&\s*\};:`,    // fork bomb
+	`/dev/null\s*>\s*/etc/`,     // overwriting /etc files
+	`>\s*/etc/passwd`,           // overwriting passwd
+	`>\s*/etc/shadow`,           // overwriting shadow
+	`shutdown`,                  // system shutdown
+	`reboot`,                    // system reboot
+	`init\s+0`,                  // system halt
+	`halt`,                      // system halt
+	`poweroff`,                  // power off
+}
+
+// NewBlocklistValidator creates a validator with the given patterns.
+func NewBlocklistValidator(patterns []string) (*BlocklistValidator, error) {
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+	for _, p := range patterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid pattern %q: %w", p, err)
+		}
+		compiled = append(compiled, re)
+	}
+	return &BlocklistValidator{patterns: compiled}, nil
+}
+
+// NewDefaultBlocklistValidator creates a validator with default dangerous patterns.
+func NewDefaultBlocklistValidator() *BlocklistValidator {
+	v, _ := NewBlocklistValidator(DefaultBlockedPatterns)
+	return v
+}
+
+// Validate checks if the command matches any blocked pattern.
+func (v *BlocklistValidator) Validate(command string) error {
+	for _, re := range v.patterns {
+		if re.MatchString(command) {
+			return &ProcessErr{
+				Type:    ProcessErrExecution,
+				Message: fmt.Sprintf("Command blocked for safety: matches pattern %q. Please use a safer alternative.", re.String()),
+			}
+		}
+	}
+	return nil
+}
+
+// BashExecutor executes bash commands with timeout and validation support.
+type BashExecutor struct {
+	timeout    time.Duration
+	workingDir string
+	validator  CommandValidator
+}
+
+// BashExecutorOption configures a BashExecutor.
+type BashExecutorOption func(*BashExecutor)
+
+// WithTimeout sets the command timeout.
+func WithTimeout(d time.Duration) BashExecutorOption {
+	return func(e *BashExecutor) {
+		e.timeout = d
+	}
+}
+
+// WithWorkingDir sets the working directory for commands.
+func WithWorkingDir(dir string) BashExecutorOption {
+	return func(e *BashExecutor) {
+		e.workingDir = dir
+	}
+}
+
+// WithValidator sets a custom command validator.
+func WithValidator(v CommandValidator) BashExecutorOption {
+	return func(e *BashExecutor) {
+		e.validator = v
+	}
+}
+
+// WithoutValidation disables command validation (use with caution).
+func WithoutValidation() BashExecutorOption {
+	return func(e *BashExecutor) {
+		e.validator = nil
+	}
+}
+
+// NewBashExecutor creates a new bash command executor.
+func NewBashExecutor(opts ...BashExecutorOption) *BashExecutor {
+	e := &BashExecutor{
+		timeout:   30 * time.Second,
+		validator: NewDefaultBlocklistValidator(),
+	}
+
+	for _, opt := range opts {
+		opt(e)
+	}
+
+	return e
+}
+
+// Execute runs a bash command and returns the output.
+func (e *BashExecutor) Execute(ctx context.Context, action Action) (Output, error) {
+	if action.Type != ActionTypeBash {
+		return Output{}, fmt.Errorf("unsupported action type: %s", action.Type)
+	}
+
+	// Validate command before execution
+	if e.validator != nil {
+		if err := e.validator.Validate(action.Command); err != nil {
+			return Output{}, err
+		}
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, e.timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(timeoutCtx, "bash", "-c", action.Command)
+
+	if e.workingDir != "" {
+		cmd.Dir = e.workingDir
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	output := Output{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+
+	if err != nil {
+		// Check if it was a timeout
+		if errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
+			output.TimedOut = true
+			return output, &ProcessErr{
+				Type:    ProcessErrTimeout,
+				Message: fmt.Sprintf("Command timed out after %s. Partial output:\n%s", e.timeout, output.String()),
+			}
+		}
+
+		// Get exit code if available
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			output.ExitCode = exitErr.ExitCode()
+		}
+
+		return output, &ProcessErr{
+			Type:    ProcessErrExecution,
+			Message: fmt.Sprintf("Command failed: %s\nOutput:\n%s", err.Error(), output.String()),
+		}
+	}
+
+	return output, nil
+}

--- a/internal/agent/parser.go
+++ b/internal/agent/parser.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Parser extracts executable actions from LLM responses.
+type Parser interface {
+	ParseAction(response string) (Action, error)
+}
+
+// commandRegex matches ```bash\n...\n``` code blocks
+var commandRegex = regexp.MustCompile("(?s)```bash\\s*\\n(.*?)\\n```")
+
+// BashParser extracts bash commands from markdown code blocks.
+type BashParser struct{}
+
+// NewBashParser creates a new bash command parser.
+func NewBashParser() *BashParser {
+	return &BashParser{}
+}
+
+// ParseAction extracts a single bash command from the response.
+func (p *BashParser) ParseAction(response string) (Action, error) {
+	matches := commandRegex.FindAllStringSubmatch(response, -1)
+
+	if len(matches) == 0 {
+		return Action{}, &ProcessErr{
+			Type:    ProcessErrFormat,
+			Message: "No bash command found. If the task is complete, respond with TASK_COMPLETE. Otherwise, provide exactly one command in ```bash``` block.",
+		}
+	}
+
+	if len(matches) > 1 {
+		return Action{}, &ProcessErr{
+			Type:    ProcessErrFormat,
+			Message: fmt.Sprintf("Found %d commands, expected exactly one. Please provide a single command in ```bash``` block.", len(matches)),
+		}
+	}
+
+	command := strings.TrimSpace(matches[0][1])
+	if command == "" {
+		return Action{}, &ProcessErr{
+			Type:    ProcessErrFormat,
+			Message: "Empty command in bash block. Please provide a valid command.",
+		}
+	}
+
+	return Action{
+		Type:    ActionTypeBash,
+		Command: command,
+	}, nil
+}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -1,0 +1,412 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+const completionMarker = "TASK_COMPLETE"
+
+// RunnerConfig holds configuration for the agent runner.
+type RunnerConfig struct {
+	MaxSteps         int           // Maximum number of steps before stopping
+	CommandTimeout   time.Duration // Timeout for each command
+	WorkingDir       string        // Working directory for commands
+	SystemPrompt     string        // Base system prompt
+	ContextThreshold int           // Character threshold to trigger summarization (0 = disabled)
+}
+
+// DefaultRunnerConfig returns a sensible default configuration.
+func DefaultRunnerConfig() RunnerConfig {
+	return RunnerConfig{
+		MaxSteps:         10,
+		CommandTimeout:   30 * time.Second,
+		SystemPrompt:     DefaultAgentSystemPrompt,
+		ContextThreshold: 8000, // Summarize when context exceeds 8K chars
+	}
+}
+
+// DefaultAgentSystemPrompt is the system prompt for the bash agent.
+const DefaultAgentSystemPrompt = `You are an autonomous agent with bash access. You can execute commands to accomplish tasks.
+
+RULES:
+1. Respond with exactly ONE bash command in a code block like this:
+` + "```bash" + `
+your command here
+` + "```" + `
+
+2. After each command, you'll see the output. Use it to decide your next action.
+
+3. When the task is complete, run:
+` + "```bash" + `
+echo "TASK_COMPLETE"
+echo "Your final summary here"
+` + "```" + `
+
+4. Be concise. Execute commands, observe results, iterate.
+
+5. If a command fails, try an alternative approach.
+
+6. You have access to common tools: curl, jq, python3, node, etc.`
+
+// Runner orchestrates the agentic loop.
+type Runner struct {
+	config   RunnerConfig
+	querier  Querier
+	parser   Parser
+	executor Executor
+	logger   *zerolog.Logger
+	output   io.Writer
+
+	messages []Message
+	step     int
+	userTask string // Original user request, used for summarization context
+}
+
+// NewRunner creates a new agent runner.
+func NewRunner(
+	config RunnerConfig,
+	querier Querier,
+	logger *zerolog.Logger,
+) *Runner {
+	var executorOpts []BashExecutorOption
+	if config.CommandTimeout > 0 {
+		executorOpts = append(executorOpts, WithTimeout(config.CommandTimeout))
+	}
+	if config.WorkingDir != "" {
+		executorOpts = append(executorOpts, WithWorkingDir(config.WorkingDir))
+	}
+
+	return &Runner{
+		config:   config,
+		querier:  querier,
+		parser:   NewBashParser(),
+		executor: NewBashExecutor(executorOpts...),
+		logger:   logger,
+		output:   io.Discard,
+		messages: []Message{},
+	}
+}
+
+// WithOutput sets the output writer for command output streaming.
+func (r *Runner) WithOutput(w io.Writer) *Runner {
+	r.output = w
+	return r
+}
+
+// RunResult contains the final output from a run.
+type RunResult struct {
+	Response   string        // Final response/summary
+	Messages   []Message     // Full conversation history
+	Steps      int           // Number of steps taken
+	TokenUsage TokenUsage    // Aggregated token usage
+	Reason     TerminationReason
+}
+
+// TokenUsage aggregates token counts across the run.
+type TokenUsage struct {
+	InputTokens  int
+	OutputTokens int
+	TotalTokens  int
+}
+
+// Run executes the agent loop until completion or error.
+// history should contain previous conversation messages (excluding system prompt and current user message).
+func (r *Runner) Run(ctx context.Context, history []Message, userPrompt string) (RunResult, error) {
+	result := RunResult{}
+
+	// Initialize conversation
+	r.messages = []Message{}
+	r.step = 0
+
+	// Store user task for summarization context
+	r.userTask = userPrompt
+
+	// Add system prompt
+	r.addMessage(RoleSystem, r.config.SystemPrompt)
+
+	// Add conversation history (previous messages from session)
+	for _, msg := range history {
+		r.addMessage(msg.Role, msg.Content)
+	}
+
+	// Add current user message
+	r.addMessage(RoleUser, userPrompt)
+
+	r.logger.Info().
+		Int("max_steps", r.config.MaxSteps).
+		Msg("Starting agent loop")
+
+	var lastResponse string
+
+	// Main loop
+	for r.step = 0; r.step < r.config.MaxSteps; r.step++ {
+		r.logger.Info().
+			Int("step", r.step+1).
+			Int("context_size", r.contextSize()).
+			Msg("Starting step")
+
+		stepResult, err := r.Step(ctx)
+		if err != nil {
+			var termErr *TerminatingErr
+			var procErr *ProcessErr
+
+			if errors.As(err, &termErr) {
+				// Clean exit - task complete or limit reached
+				r.logger.Info().
+					Str("reason", string(termErr.Reason)).
+					Msg("Agent terminated")
+				result.Response = termErr.Output
+				result.Reason = termErr.Reason
+				result.Messages = r.messages
+				result.Steps = r.step + 1
+				return result, nil
+			}
+
+			if errors.As(err, &procErr) {
+				// Recoverable - add feedback and continue
+				r.logger.Warn().
+					Str("type", string(procErr.Type)).
+					Str("message", procErr.Message).
+					Msg("Process error, continuing")
+				r.addMessage(RoleUser, procErr.Message)
+				continue
+			}
+
+			// Unrecoverable error
+			r.logger.Error().Err(err).Msg("Unrecoverable error")
+			return result, err
+		}
+
+		// Accumulate token usage
+		result.TokenUsage.InputTokens += stepResult.InputTokens
+		result.TokenUsage.OutputTokens += stepResult.OutputTokens
+		result.TokenUsage.TotalTokens += stepResult.TotalTokens
+
+		lastResponse = stepResult.Response
+	}
+
+	// Step limit reached
+	r.logger.Warn().
+		Int("max_steps", r.config.MaxSteps).
+		Msg("Step limit reached")
+
+	result.Response = lastResponse
+	result.Reason = ReasonStepLimit
+	result.Messages = r.messages
+	result.Steps = r.step
+	return result, &TerminatingErr{Reason: ReasonStepLimit}
+}
+
+// StepResult contains the output from a single step.
+type StepResult struct {
+	Response     string
+	Command      string
+	Output       Output
+	InputTokens  int
+	OutputTokens int
+	TotalTokens  int
+}
+
+// Step performs a single iteration of the agent loop.
+func (r *Runner) Step(ctx context.Context) (StepResult, error) {
+	if err := ctx.Err(); err != nil {
+		return StepResult{}, fmt.Errorf("context cancelled: %w", err)
+	}
+
+	r.logger.Debug().Msg("Querying model")
+
+	// 1. Query the model
+	queryResult, err := r.querier.Query(ctx, r.messages)
+	if err != nil {
+		r.logger.Error().Err(err).Msg("Query failed")
+		return StepResult{}, fmt.Errorf("query failed: %w", err)
+	}
+
+	r.logger.Debug().
+		Int("response_length", len(queryResult.Content)).
+		Int("input_tokens", queryResult.InputTokens).
+		Int("output_tokens", queryResult.OutputTokens).
+		Msg("Got response")
+
+	result := StepResult{
+		Response:     queryResult.Content,
+		InputTokens:  queryResult.InputTokens,
+		OutputTokens: queryResult.OutputTokens,
+		TotalTokens:  queryResult.TotalTokens,
+	}
+
+	// 2. Parse action from response
+	action, err := r.parser.ParseAction(queryResult.Content)
+	if err != nil {
+		r.logger.Debug().Err(err).Msg("Failed to parse action")
+		return result, err
+	}
+	result.Command = action.Command
+
+	// 3. Add assistant message before execution
+	r.addMessage(RoleAssistant, queryResult.Content)
+
+	// 4. Execute the command and stream output
+	fmt.Fprintf(r.output, "$ %s\n", action.Command)
+
+	r.logger.Info().
+		Str("command", action.Command).
+		Msg("Executing command")
+
+	output, err := r.executor.Execute(ctx, action)
+	result.Output = output
+
+	if err != nil {
+		r.logger.Warn().Err(err).Msg("Command execution failed")
+		return result, err
+	}
+
+	// Print output (skip if it's just the completion marker)
+	if !r.isTaskComplete(output) && strings.TrimSpace(output.Stdout) != "" {
+		fmt.Fprintln(r.output, output.Stdout)
+	}
+
+	r.logger.Debug().
+		Int("output_length", len(output.String())).
+		Int("exit_code", output.ExitCode).
+		Msg("Command completed")
+
+	// 5. Check for completion signal in command output
+	if r.isTaskComplete(output) {
+		r.logger.Info().Msg("Task complete signal in output")
+		finalOutput := r.extractFinalOutput(output)
+		return result, &TerminatingErr{
+			Reason: ReasonComplete,
+			Output: finalOutput,
+		}
+	}
+
+	// 6. Format observation (with optional summarization)
+	feedback := r.formatObservation(output)
+
+	// 7. Summarize if context is getting too large
+	if r.shouldSummarize(len(feedback)) {
+		summarized, err := r.summarizeOutput(ctx, feedback)
+		if err != nil {
+			r.logger.Warn().Err(err).Msg("Failed to summarize, using truncated output")
+		} else {
+			feedback = summarized
+		}
+	}
+
+	// 8. Add execution result as user message
+	r.addMessage(RoleUser, feedback)
+
+	return result, nil
+}
+
+// isTaskComplete checks if the command output starts with the completion signal.
+func (r *Runner) isTaskComplete(output Output) bool {
+	firstLine := strings.SplitN(strings.TrimSpace(output.Stdout), "\n", 2)[0]
+	return strings.TrimSpace(firstLine) == completionMarker
+}
+
+// extractFinalOutput returns everything after the completion marker.
+func (r *Runner) extractFinalOutput(output Output) string {
+	parts := strings.SplitN(output.Stdout, "\n", 2)
+	if len(parts) > 1 {
+		return strings.TrimSpace(parts[1])
+	}
+	return ""
+}
+
+// formatObservation formats command output for the LLM.
+func (r *Runner) formatObservation(output Output) string {
+	if strings.TrimSpace(output.Stdout) == "" && output.ExitCode == 0 {
+		return "(no output)"
+	}
+
+	result := output.Stdout
+
+	// Truncate long output to keep context manageable
+	const maxLen = 3000
+	if len(result) > maxLen {
+		head := result[:maxLen/2]
+		tail := result[len(result)-maxLen/2:]
+		result = head + "\n\n[... output truncated ...]\n\n" + tail
+	}
+
+	// Add exit code if non-zero
+	if output.ExitCode != 0 {
+		result = fmt.Sprintf("[exit code: %d]\n%s", output.ExitCode, result)
+	}
+
+	return result
+}
+
+// addMessage appends a message to the conversation history.
+func (r *Runner) addMessage(role Role, content string) {
+	r.messages = append(r.messages, Message{
+		Role:    role,
+		Content: content,
+	})
+	r.logger.Debug().
+		Str("role", string(role)).
+		Int("content_length", len(content)).
+		Msg("Message added")
+}
+
+// Messages returns the current conversation history.
+func (r *Runner) Messages() []Message {
+	return r.messages
+}
+
+// contextSize returns the total character count of all messages.
+func (r *Runner) contextSize() int {
+	total := 0
+	for _, msg := range r.messages {
+		total += len(msg.Content)
+	}
+	return total
+}
+
+// shouldSummarize returns true if context is large and output is substantial.
+func (r *Runner) shouldSummarize(outputLen int) bool {
+	if r.config.ContextThreshold <= 0 {
+		return false
+	}
+	// Summarize if context exceeds threshold and output is substantial (>500 chars)
+	return r.contextSize() > r.config.ContextThreshold && outputLen > 500
+}
+
+// summarizeOutput asks the model to extract relevant information from large output.
+func (r *Runner) summarizeOutput(ctx context.Context, output string) (string, error) {
+	prompt := []Message{
+		{
+			Role: RoleSystem,
+			Content: "You are a data extraction assistant. Extract only the specific information needed to answer the user's question. Be concise and preserve exact values (especially dollar amounts).",
+		},
+		{
+			Role: RoleUser,
+			Content: fmt.Sprintf("User's question: %s\n\nCommand output:\n%s\n\nExtract only the relevant data needed to answer the question:", r.userTask, output),
+		},
+	}
+
+	r.logger.Info().
+		Int("output_length", len(output)).
+		Msg("Summarizing large output")
+
+	result, err := r.querier.Query(ctx, prompt)
+	if err != nil {
+		return "", fmt.Errorf("summarization failed: %w", err)
+	}
+
+	r.logger.Debug().
+		Int("original_length", len(output)).
+		Int("summarized_length", len(result.Content)).
+		Msg("Output summarized")
+
+	return "[Summarized] " + result.Content, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,10 +1,18 @@
 package config
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/fx"
 )
 
+// Config holds all configuration from environment variables.
 type Config struct {
 	Token        string `envconfig:"TELEGRAM_API_TOKEN" required:"true"`
 	APIKey       string `envconfig:"OPENROUTER_API_KEY" required:"true"`
@@ -12,20 +20,168 @@ type Config struct {
 	Model        string `envconfig:"OPENROUTER_MODEL" default:"anthropic/claude-3.5-sonnet"`
 	HistoryLimit int    `envconfig:"HISTORY_LIMIT" default:"10"`
 	DatabaseURL  string `envconfig:"DATABASE_URL" required:"true"`
+
+	// Agentic mode settings
+	AgenticMode      bool          `envconfig:"AGENTIC_MODE" default:"false"`
+	MaxSteps         int           `envconfig:"MAX_STEPS" default:"10"`
+	CommandTimeout   time.Duration `envconfig:"COMMAND_TIMEOUT" default:"30s"`
+	WorkingDir       string        `envconfig:"WORKING_DIR" default:""`
+	ContextThreshold int           `envconfig:"CONTEXT_THRESHOLD" default:"8000"` // Chars before summarization kicks in
+
+	// Path to config.toml file
+	ConfigFile string `envconfig:"CONFIG_FILE" default:"config.toml"`
+
+	// Path to context directory containing .md files to inject into prompts
+	ContextDir string `envconfig:"CONTEXT_DIR" default:".context"`
+
+	// Prompts loaded from config.toml
+	Prompts Prompts
+
+	// Context loaded from .context/*.md files
+	Context string
 }
 
-// LoadEnv loads the configuration from environment variables
+// Prompts holds system prompts loaded from config.toml.
+type Prompts struct {
+	Simple string `toml:"simple"`
+	Agent  string `toml:"agent"`
+}
+
+// FileConfig represents the structure of config.toml.
+type FileConfig struct {
+	Prompts Prompts `toml:"prompts"`
+}
+
+// DefaultPrompts provides fallback prompts if config.toml is not found.
+var DefaultPrompts = Prompts{
+	Simple: "Provide brief, concise responses with a friendly and human tone. Do not use markdown formatting.",
+	Agent: `You are an autonomous agent with bash access. You can execute commands to accomplish tasks.
+
+RULES:
+1. Respond with exactly ONE bash command in a code block like this:
+` + "```bash" + `
+your command here
+` + "```" + `
+
+2. After each command, you'll see the output. Use it to decide your next action.
+
+3. When the task is complete, run:
+` + "```bash" + `
+echo "TASK_COMPLETE"
+echo "Your final summary here"
+` + "```" + `
+
+4. Be concise. Execute commands, observe results, iterate.
+
+5. If a command fails, try an alternative approach.
+
+6. You have access to common tools: curl, jq, python3, node, etc.`,
+}
+
+// LoadEnv loads the configuration from environment variables.
 func (c Config) LoadEnv() (Config, error) {
 	cfg := c
 
-	// load environment variables into the Config struct
 	if err := envconfig.Process("", &cfg); err != nil {
-		// if there is an error, return the default config and the error
 		return c, err
 	}
 
-	// return the loaded config
 	return cfg, nil
+}
+
+// LoadFile loads prompts from config.toml file.
+func (c *Config) LoadFile() error {
+	// Try to find config file
+	configPath := c.ConfigFile
+	if !filepath.IsAbs(configPath) {
+		// Try current directory first
+		if _, err := os.Stat(configPath); os.IsNotExist(err) {
+			// Try executable directory
+			execPath, err := os.Executable()
+			if err == nil {
+				execDir := filepath.Dir(execPath)
+				configPath = filepath.Join(execDir, c.ConfigFile)
+			}
+		}
+	}
+
+	// Check if file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		// Use defaults if no config file
+		c.Prompts = DefaultPrompts
+		return nil
+	}
+
+	// Load TOML file
+	var fileConfig FileConfig
+	if _, err := toml.DecodeFile(configPath, &fileConfig); err != nil {
+		return err
+	}
+
+	c.Prompts = fileConfig.Prompts
+
+	// Use defaults for empty prompts
+	if c.Prompts.Simple == "" {
+		c.Prompts.Simple = DefaultPrompts.Simple
+	}
+	if c.Prompts.Agent == "" {
+		c.Prompts.Agent = DefaultPrompts.Agent
+	}
+
+	return nil
+}
+
+// LoadContext loads all .md files from the context directory and concatenates them.
+func (c *Config) LoadContext() error {
+	// Check if context directory exists
+	if _, err := os.Stat(c.ContextDir); os.IsNotExist(err) {
+		// No context directory, that's fine
+		return nil
+	}
+
+	// Find all .md files in context directory
+	pattern := filepath.Join(c.ContextDir, "*.md")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		return fmt.Errorf("failed to glob context files: %w", err)
+	}
+
+	if len(files) == 0 {
+		return nil
+	}
+
+	// Read and concatenate all files
+	var parts []string
+	for _, file := range files {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			return fmt.Errorf("failed to read context file %s: %w", file, err)
+		}
+		parts = append(parts, string(content))
+	}
+
+	c.Context = strings.Join(parts, "\n\n---\n\n")
+
+	return nil
+}
+
+// AgentPrompt returns the agent prompt with context injected.
+func (c *Config) AgentPrompt() string {
+	// Prepend today's date so the agent knows the current date
+	dateHeader := fmt.Sprintf("Today's date: %s\n\n", time.Now().Format("2006-01-02"))
+
+	if c.Context == "" {
+		return dateHeader + c.Prompts.Agent
+	}
+	return dateHeader + c.Prompts.Agent + "\n\n## Available Tools & Context\n\n" + c.Context
+}
+
+// SimplePrompt returns the simple prompt with context injected.
+func (c *Config) SimplePrompt() string {
+	if c.Context == "" {
+		return c.Prompts.Simple
+	}
+	return c.Prompts.Simple + "\n\n## Available Tools & Context\n\n" + c.Context
 }
 
 func NewConfig() (*Config, error) {
@@ -34,6 +190,17 @@ func NewConfig() (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Load prompts from config.toml
+	if err := loadedCfg.LoadFile(); err != nil {
+		return nil, err
+	}
+
+	// Load context from .context/*.md files
+	if err := loadedCfg.LoadContext(); err != nil {
+		return nil, err
+	}
+
 	return &loadedCfg, nil
 }
 


### PR DESCRIPTION
- add agentic loop with bash command execution
- add conversation history support in agentic mode
- add context tracking with auto-summarization for large outputs
- add perioditc Telegram typing indicator during multi-step run
- add configurable context threshold via env var CONTEXT_THRESHOLD
- redce output truncation to 3K chars for better context management
- make prompts confiurable via config.toml
- add config.toml.example as generic template